### PR TITLE
Fix try/catch/finally il code generation

### DIFF
--- a/src/Pose/IL/MethodRewriter.cs
+++ b/src/Pose/IL/MethodRewriter.cs
@@ -169,14 +169,6 @@ namespace Pose.IL
                 ilGenerator.BeginExceptionBlock();
             }
 
-            foreach (var handler in handlers.Where(h => h.HandlerStart == instruction.Offset))
-            {
-                if (handler.Flag == "Clause")
-                    ilGenerator.BeginCatchBlock(handler.CatchType);
-                else if (handler.Flag == "Finally")
-                    ilGenerator.BeginFinallyBlock();
-            }
-
             foreach (var handler in handlers.Where(h => h.HandlerEnd == instruction.Offset))
             {
                 if (handler.Flag == "Clause")
@@ -189,6 +181,14 @@ namespace Pose.IL
                 }
 
                 ilGenerator.EndExceptionBlock();
+            }
+            
+            foreach (var handler in handlers.Where(h => h.HandlerStart == instruction.Offset))
+            {
+                if (handler.Flag == "Clause")
+                    ilGenerator.BeginCatchBlock(handler.CatchType);
+                else if (handler.Flag == "Finally")
+                    ilGenerator.BeginFinallyBlock();
             }
         }
 

--- a/test/Pose.Tests/IL/MethodRewriterTests.cs
+++ b/test/Pose.Tests/IL/MethodRewriterTests.cs
@@ -50,5 +50,29 @@ namespace Pose.Tests
             Assert.AreEqual(typeof(void), dynamicMethod.ReturnType);
             Assert.AreEqual(typeof(List<string>), dynamicMethod.GetParameters()[0].ParameterType);
         }
+        
+        [TestMethod]
+        public void TestExceptionHandlersRewrite()
+        {
+            MethodInfo methodInfo = typeof(MethodRewriterTests).GetMethod("ExceptionHandlersRewriteMethod");
+            MethodRewriter methodRewriter = MethodRewriter.CreateRewriter(methodInfo);
+            DynamicMethod dynamicMethod = methodRewriter.Rewrite() as DynamicMethod;
+
+            Delegate func = dynamicMethod.CreateDelegate(typeof(Func<int>));
+            Assert.AreEqual(1, (int)func.DynamicInvoke());
+        }
+
+        public static int ExceptionHandlersRewriteMethod()
+        {
+            try
+            {
+                return 1;
+            }
+            catch
+            {
+                return 0;
+            }
+            finally {}
+        }
     }
 }


### PR DESCRIPTION
There is some problem with methods contain try/catch/finally statement.

```
Pose.Tests.MethodRewriterTests.TestExceptionHandlersRewrite

Test method Pose.Tests.MethodRewriterTests.TestExceptionHandlersRewrite threw exception: 
System.InvalidOperationException: Incorrect code generation for exception block.
   at System.Reflection.Emit.ILGenerator.EndExceptionBlock()
   at Pose.IL.MethodRewriter.EmitILForExceptionHandlers(ILGenerator ilGenerator, Instruction instruction, List`1 handlers)
   at Pose.IL.MethodRewriter.Rewrite()
   at Pose.Tests.MethodRewriterTests.TestExceptionHandlersRewrite()
```

Wrong exception handler instruction order failed:

1. begin exception block
2. begin exception block
3. begin catch handler
4. **begin finally handler**
5. **end catch handler**
6. end finally handler

I have fixed instruction order. Now order is:

1. begin exception block
2. begin exception block
3. begin catch handler
4. **end catch handler**
5. **begin finally handler**
6. end finally handler